### PR TITLE
Fix left click con cape tele to poh

### DIFF
--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
@@ -216,7 +216,7 @@ public class MenuSwapperPlugin extends Plugin implements KeyListener
 		{
 			swap(config.swapKaramjaGlovesLeftClick().getOption().toLowerCase(), option, target, index);
 		}
-		else if (!shiftHeld && config.swapConsCape() && (option.equals("teleport")) && (target.startsWith("construct. cape")))
+		else if (!shiftHeld && config.swapConsCape() && (option.equals("wear")) && (target.startsWith("construct. cape")))
 		{
 			swap("tele to poh", option, target, index);
 		}


### PR DESCRIPTION
`teleport` is not the default left click option. Changing it to `wear` fixes the swap. Works regardless of whether `Teleport item` is enabled in RuneLite's Menu Entry Swapper config or not.