### PR TITLE
Add Desert Amulet swap

### DIFF
--- a/src/main/java/io/ryoung/menuswapperextended/DesertAmuletMode.java
+++ b/src/main/java/io/ryoung/menuswapperextended/DesertAmuletMode.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020, SomeZer0
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.ryoung.menuswapperextended;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DesertAmuletMode
+{
+ 	WEAR("Wear"),
+	NARDAH("Nardah"),
+	KALPHITE CAVE("Kalphite cave");
+
+	private final String option;
+
+	@Override
+	public String toString()
+	{
+		return option;
+	}
+}

--- a/src/main/java/io/ryoung/menuswapperextended/DesertAmuletMode.java
+++ b/src/main/java/io/ryoung/menuswapperextended/DesertAmuletMode.java
@@ -33,7 +33,7 @@ public enum DesertAmuletMode
 {
  	WEAR("Wear"),
 	NARDAH("Nardah"),
-	KALPHITE CAVE("Kalphite cave");
+	KALPHITE_CAVE("Kalphite cave");
 
 	private final String option;
 

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
@@ -199,4 +199,13 @@ public interface MenuSwapperConfig extends Config
 	{
 		return PharaohSceptreMode.JALSAVRAH;
 	}
+	@ConfigItem(
+			keyName = "swapDesertAmuletLeftClick",
+			name = "Desert Amulet",
+			description = "Change the left-click option on Desert Amulet"
+	)
+	default DesertAmuletMode swapDesertAmuletLeftClick()
+	{
+		return DesertAmuletMode.WEAR;
+	}
 }

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
@@ -228,7 +228,7 @@ public class MenuSwapperPlugin extends Plugin implements KeyListener
 		{
 			swap(config.swapPharaohSceptreLeftClick().getOption().toLowerCase(), option, target, index);
 		}
-			else if (!shiftHeld && target.startsWith("desert amulet") && option.equals("wear"))
+		else if (!shiftHeld && target.startsWith("desert amulet") && option.equals("wear"))
 		{
 			swap(config.swapDesertAmuletLeftClick().getOption().toLowerCase(), option, target, index);
 		}

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
@@ -228,6 +228,10 @@ public class MenuSwapperPlugin extends Plugin implements KeyListener
 		{
 			swap(config.swapPharaohSceptreLeftClick().getOption().toLowerCase(), option, target, index);
 		}
+			else if (!shiftHeld && target.startsWith("desert amulet") && option.equals("wear"))
+		{
+			swap(config.swapDesertAmuletLeftClick().getOption().toLowerCase(), option, target, index);
+		}
 	}
 
 	private int searchIndex(MenuEntry[] entries, String option, String target, boolean strict)


### PR DESCRIPTION
Desert Amulet is a teleportation item that is not covered by RuneLite's standard MES under "Teleport item"
Here is the default right-click menu for the item:
![Right Click Menu](https://i.imgur.com/i9DWGm7.png)