### PR TITLE
Add Seed Box swap

### DIFF
--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
@@ -241,4 +241,14 @@ public interface MenuSwapperConfig extends Config
 	{
 		return CharterShipsMode.LAST_DESTINATION;
 	}
+	
+	@ConfigItem(
+		keyName = "swapSeedBox",
+		name = "Seed Box",
+		description = "Swaps the Seed Box left-click option from Fill to Check"
+	)
+	default boolean swapSeedBox()
+	{
+		return false;
+	}
 }

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
@@ -196,6 +196,13 @@ public class MenuSwapperPlugin extends Plugin implements KeyListener
 				swap(config.swapArdougneCloakLeftClick().getOption().toLowerCase(), option, target, index);
 			}
 		}
+		else if (!shiftHeld && option.equals("fill"))
+		{
+			if (config.swapSeedBox() && (target.contains("seed box")))
+			{
+				swap("check", option, target, index);
+			}
+		}
 		else if (option.equals("attack"))
 		{
 			if (config.swapStun() && target.contains("hoop snake"))


### PR DESCRIPTION
The "Check" option is used to open the interface of the seed box that lets you withdraw seeds from it.
![Right Click Closed Box](https://i.imgur.com/KhzYKTd.png)
The "Open" option works similarly to opening a Looting Bag. It also gives the item a different name. A swap is not needed for this, or any of the other options.
![Right Click Open Box](https://i.imgur.com/a5KB2tl.png)