### PR TITLE
Add "join" to minigame swaps for Last Man Standing

### DIFF
--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
@@ -156,6 +156,7 @@ public class MenuSwapperPlugin extends Plugin implements KeyListener
 				swap("start-minigame", option, target, index);
 				swap("dream", option, target, index);
 				swap("escort", option, target, index);
+				swap("join", option, target, index);
 			}
 
 			if (config.swapSendParcel())


### PR DESCRIPTION
Swaps "talk-to" with "join" to more quickly enter games of Last Man Standing.

<img width="355" alt="Screen Shot 2020-07-08 at 2 17 15 PM" src="https://user-images.githubusercontent.com/54762282/86956215-beaabd00-c126-11ea-89f7-1d686775b799.png">
