### PR TITLE
Add support for ardougne max cape

### DIFF
--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
@@ -202,7 +202,7 @@ public class MenuSwapperPlugin extends Plugin implements KeyListener
 			{
 				swap(config.swapMorytaniaLegsLeftClick().getOption().toLowerCase(), option, target, index);
 			}
-			else if (target.startsWith("ardougne cloak"))
+			else if (target.startsWith("ardougne cloak") || target.startsWith("ardougne max cape"))
 			{
 				swap(config.swapArdougneCloakLeftClick().getOption().toLowerCase(), option, target, index);
 			}


### PR DESCRIPTION
Currently the `Ardougne Cloak` config option does not effect the Ardougne Max cape. This addition enables the config to change the left click option for the max cape variant in addition to the regular ardy cloak.

<img width="220" alt="Screen Shot 2020-07-08 at 8 18 03 PM" src="https://user-images.githubusercontent.com/54762282/86983341-a607ca80-c159-11ea-8d6c-bd57d8724a00.png">
