### PR TITLE
add rune essence pouch swap

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.16-SNAPSHOT'
+def runeLiteVersion = '1.6.23'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
@@ -281,4 +281,14 @@ public interface MenuSwapperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+			keyName = "swapEssencePouch",
+			name = "Essence Pouch",
+			description = "Swaps fill with Empty on Rune Essence pouches"
+	)
+	default boolean swapEssencePouch()
+	{
+		return false;
+	}
 }

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
@@ -275,6 +275,10 @@ public class MenuSwapperPlugin extends Plugin implements KeyListener
 		{
 			swap(config.swapSpellbookSwapLeftClick().getOption().toLowerCase(), option, target, index);
 		}
+		else if (target.endsWith("pouch") && option.equals("fill"))
+		{
+			swap("empty", option, target, index);
+		}
 	}
 
 	private int searchIndex(MenuEntry[] entries, String option, String target, boolean strict)


### PR DESCRIPTION
This PR simply adds the ability to make empty the default left click option on Rune essence pouches.