### PR TITLE
Add God Wars Dungeon private instance swap for TB League

### DIFF
--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
@@ -281,4 +281,14 @@ public interface MenuSwapperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "swapGodWarsDoor",
+		name = "God Wars Private Instance",
+		description = "Swaps the normal and private GWD rooms for Trailblazer League"
+	)
+	default boolean swapGodWarsDoor()
+	{
+		return false;
+	}
 }

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
@@ -275,6 +275,10 @@ public class MenuSwapperPlugin extends Plugin implements KeyListener
 		{
 			swap(config.swapSpellbookSwapLeftClick().getOption().toLowerCase(), option, target, index);
 		}
+		else if (config.swapGodWarsDoor() && option.equals("open (normal)") && target.contains("big door"))
+		{
+			swap("open (private)", option, target, index);
+		}
 	}
 
 	private int searchIndex(MenuEntry[] entries, String option, String target, boolean strict)


### PR DESCRIPTION
Enables left-click to enter private instances on the God Wars Dungeon doors in Leagues II

![image](https://user-images.githubusercontent.com/54762282/98483034-5999cd80-21d3-11eb-84c1-ee2c9d670c3c.png)
