### PR TITLE
Rune Pouch swap Fill with Empty

### DIFF
--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
@@ -357,4 +357,15 @@ public interface MenuSwapperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "swapRunePouch",
+		name = "Rune pouch",
+		description = "Swaps Fill with Empty for all Rune pouches",
+		section = itemSection
+	)
+	default boolean swapRunePouch()
+	{
+		return false;
+	}
 }

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
@@ -283,6 +283,11 @@ public class MenuSwapperPlugin extends Plugin implements KeyListener
 		{
 			swap("pet", option, target, index);
 		}
+		else if (config.swapRunePouch() && option.equals("fill") && (target.equals("small pouch") ||
+			target.equals("medium pouch") || target.equals("large pouch") || target.equals("giant pouch"))
+		{
+			swap("empty", option, target, index);
+		}
 	}
 
 	private int searchIndex(MenuEntry[] entries, String option, String target, boolean strict)


### PR DESCRIPTION
For training Runecraft, to make emptying essence pouches a bit easier.