### PR TITLE
Adds configurable modifier keys for each bank menu entry.

### DIFF
--- a/src/main/java/io/ryoung/menuswapperextended/BankSwapMode.java
+++ b/src/main/java/io/ryoung/menuswapperextended/BankSwapMode.java
@@ -1,0 +1,49 @@
+package io.ryoung.menuswapperextended;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.MenuAction;
+import net.runelite.client.config.Keybind;
+import net.runelite.client.plugins.menuentryswapper.ShiftDepositMode;
+import net.runelite.client.plugins.menuentryswapper.ShiftWithdrawMode;
+
+import java.util.function.Function;
+
+@Getter
+@RequiredArgsConstructor
+enum BankSwapMode {
+    OFF(ShiftDepositMode.OFF, ShiftWithdrawMode.OFF, config -> Keybind.NOT_SET),
+    SWAP_1(ShiftDepositMode.DEPOSIT_1, ShiftWithdrawMode.WITHDRAW_1, config -> config.getBankSwap1Hotkey()),
+    SWAP_5(ShiftDepositMode.DEPOSIT_5, ShiftWithdrawMode.WITHDRAW_5, config -> config.getBankSwap5Hotkey()),
+    SWAP_10(ShiftDepositMode.DEPOSIT_10, ShiftWithdrawMode.WITHDRAW_10, config -> config.getBankSwap10Hotkey()),
+    SWAP_X(ShiftDepositMode.DEPOSIT_X, ShiftWithdrawMode.WITHDRAW_X, config -> config.getBankSwapXHotkey()),
+    SWAP_SET_X(7, 6, 5, MenuAction.CC_OP_LOW_PRIORITY, 6, 5, config -> config.getBankSwapSetXHotkey()),
+    SWAP_ALL(ShiftDepositMode.DEPOSIT_ALL, ShiftWithdrawMode.WITHDRAW_ALL, config -> config.getBankSwapAllHotkey()),
+    SWAP_ALL_BUT_1(-1, -1, -1, ShiftWithdrawMode.WITHDRAW_ALL_BUT_1.getMenuAction(), ShiftWithdrawMode.WITHDRAW_ALL_BUT_1.getIdentifier(), ShiftWithdrawMode.WITHDRAW_ALL_BUT_1.getIdentifierChambersStorageUnit(), config -> config.getBankSwapAllBut1Hotkey()),
+    SWAP_EXTRA_OP(ShiftDepositMode.EXTRA_OP.getIdentifier(), ShiftDepositMode.EXTRA_OP.getIdentifierDepositBox(), ShiftDepositMode.EXTRA_OP.getIdentifierChambersStorageUnit(), null, -1, -1, config -> config.getBankSwapExtraOpHotkey()),
+    ;
+
+    private final int depositIdentifier;
+    private final int depositIdentifierDepositBox;
+    private final int depositIdentifierChambersStorageUnit;
+
+    private final MenuAction withdrawMenuAction;
+    private final int withdrawIdentifier;
+    private final int withdrawIdentifierChambersStorageUnit;
+
+    private final Function<MenuSwapperConfig, Keybind> keybindFunction;
+
+    BankSwapMode(ShiftDepositMode depositMode, ShiftWithdrawMode withdrawMode, Function<MenuSwapperConfig, Keybind> keybindFunction) {
+        depositIdentifier = depositMode.getIdentifier();
+        depositIdentifierDepositBox = depositMode.getIdentifierDepositBox();
+        depositIdentifierChambersStorageUnit = depositMode.getIdentifierChambersStorageUnit();
+        withdrawMenuAction = withdrawMode.getMenuAction();
+        withdrawIdentifier = withdrawMode.getIdentifier();
+        withdrawIdentifierChambersStorageUnit = withdrawMode.getIdentifierChambersStorageUnit();
+        this.keybindFunction = keybindFunction;
+    }
+
+    public Keybind getKeybind(MenuSwapperConfig config) {
+        return keybindFunction.apply(config);
+    }
+}

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
@@ -29,6 +29,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.Keybind;
 
 @ConfigGroup("menuswapperextended")
 public interface MenuSwapperConfig extends Config
@@ -312,6 +313,102 @@ public interface MenuSwapperConfig extends Config
 	default SpellbookSwapMode swapSpellbookSwapLeftClick()
 	{
 		return SpellbookSwapMode.CAST;
+	}
+
+	@ConfigItem(
+			keyName = "bankSwap1Hotkey",
+			name = "Bank 1",
+			description = "The hotkey which, when held, swaps the bank's withdraw/deposit 1 option",
+			section = uiSection,
+			position = 0
+	)
+	default Keybind getBankSwap1Hotkey()
+	{
+		return Keybind.NOT_SET;
+	}
+
+	@ConfigItem(
+			keyName = "bankSwap5Hotkey",
+			name = "Bank 5",
+			description = "The hotkey which, when held, swaps the bank's withdraw/deposit 5 option",
+			section = uiSection,
+			position = 1
+	)
+	default Keybind getBankSwap5Hotkey()
+	{
+		return Keybind.NOT_SET;
+	}
+
+	@ConfigItem(
+			keyName = "bankSwap10Hotkey",
+			name = "Bank 10",
+			description = "The hotkey which, when held, swaps the bank's withdraw/deposit 10 option",
+			section = uiSection,
+			position = 2
+	)
+	default Keybind getBankSwap10Hotkey()
+	{
+		return Keybind.NOT_SET;
+	}
+
+	@ConfigItem(
+			keyName = "bankSwapXHotkey",
+			name = "Bank X",
+			description = "The hotkey which, when held, swaps the bank's withdraw/deposit X option",
+			section = uiSection,
+			position = 3
+	)
+	default Keybind getBankSwapXHotkey()
+	{
+		return Keybind.NOT_SET;
+	}
+
+	@ConfigItem(
+			keyName = "bankSwapSetXHotkey",
+			name = "Bank Set-X",
+			description = "The hotkey which, when held, swaps the bank's withdraw/deposit SetX option",
+			section = uiSection,
+			position = 4
+	)
+	default Keybind getBankSwapSetXHotkey()
+	{
+		return Keybind.NOT_SET;
+	}
+
+	@ConfigItem(
+			keyName = "bankSwapAllHotkey",
+			name = "Bank All",
+			description = "The hotkey which, when held, swaps the bank's withdraw/deposit All option",
+			section = uiSection,
+			position = 5
+	)
+	default Keybind getBankSwapAllHotkey()
+	{
+		return Keybind.NOT_SET;
+	}
+
+	@ConfigItem(
+			keyName = "bankSwapAllBut1Hotkey",
+			name = "Bank All-But-1",
+			description = "The hotkey which, when held, swaps the bank's withdraw/deposit AllBut1 option",
+			section = uiSection,
+			position = 6
+	)
+	default Keybind getBankSwapAllBut1Hotkey()
+	{
+		return Keybind.NOT_SET;
+	}
+
+	@ConfigItem(
+			keyName = "bankSwapEquipUseWieldHotkey",
+			name = "Bank Eat/Wield/Etc.",
+			description = "The hotkey which, when held, swaps the bank's EquipUseWield option",
+			section = uiSection,
+			position = 7
+	)
+	default Keybind getBankSwapExtraOpHotkey()
+	{
+		return Keybind.NOT_SET;
 	}
 
 	@ConfigItem(

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
@@ -40,6 +40,9 @@ import net.runelite.api.MenuEntry;
 import net.runelite.api.NPC;
 import net.runelite.api.events.ClientTick;
 import net.runelite.api.events.FocusChanged;
+import net.runelite.api.events.MenuEntryAdded;
+import net.runelite.api.widgets.WidgetID;
+import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.input.KeyListener;
@@ -72,6 +75,8 @@ public class MenuSwapperPlugin extends Plugin implements KeyListener
 	private KeyManager keyManager;
 
 	private boolean shiftHeld = false;
+
+	private BankSwapMode currentBankModeSwap = BankSwapMode.OFF;
 
 	@Provides
 	MenuSwapperConfig provideConfig(ConfigManager configManager)
@@ -418,6 +423,13 @@ public class MenuSwapperPlugin extends Plugin implements KeyListener
 		{
 			shiftHeld = true;
 		}
+
+		for (BankSwapMode swapMode : BankSwapMode.values()) {
+			if ((swapMode.getKeybind(config)).matches(e)) {
+				currentBankModeSwap = swapMode;
+				break;
+			}
+		}
 	}
 
 	@Override
@@ -427,6 +439,13 @@ public class MenuSwapperPlugin extends Plugin implements KeyListener
 		{
 			shiftHeld = false;
 		}
+
+		for (BankSwapMode swapMode : BankSwapMode.values()) {
+			if ((swapMode.getKeybind(config)).matches(e) && currentBankModeSwap.equals(swapMode)) {
+				currentBankModeSwap = BankSwapMode.OFF;
+				break;
+			}
+		}
 	}
 
 	@Subscribe
@@ -435,7 +454,62 @@ public class MenuSwapperPlugin extends Plugin implements KeyListener
 		if (!event.isFocused())
 		{
 			shiftHeld = false;
+
+			currentBankModeSwap = BankSwapMode.OFF;
 		}
 	}
+
+	@Subscribe
+	public void onMenuEntryAdded(MenuEntryAdded menuEntryAdded) {
+		final int widgetGroupId = WidgetInfo.TO_GROUP(menuEntryAdded.getActionParam1());
+
+		// Deposit- op 1 is the current withdraw amount 1/5/10/x for deposit box interface and chambers of xeric storage unit.
+		// Deposit- op 2 is the current withdraw amount 1/5/10/x for bank interface
+		if (currentBankModeSwap != BankSwapMode.OFF && currentBankModeSwap != BankSwapMode.SWAP_ALL_BUT_1
+				&& menuEntryAdded.getType() == MenuAction.CC_OP.getId()
+				&& (menuEntryAdded.getIdentifier() == 2 || menuEntryAdded.getIdentifier() == 1)
+				&& (menuEntryAdded.getOption().startsWith("Deposit-") || menuEntryAdded.getOption().startsWith("Store") || menuEntryAdded.getOption().startsWith("Donate"))) {
+			final int opId = widgetGroupId == WidgetID.DEPOSIT_BOX_GROUP_ID ? currentBankModeSwap.getDepositIdentifierDepositBox()
+					: widgetGroupId == WidgetID.CHAMBERS_OF_XERIC_STORAGE_UNIT_INVENTORY_GROUP_ID ? currentBankModeSwap.getDepositIdentifierChambersStorageUnit()
+					: currentBankModeSwap.getDepositIdentifier();
+			final int actionId = opId >= 6 ? MenuAction.CC_OP_LOW_PRIORITY.getId() : MenuAction.CC_OP.getId();
+			bankModeSwap(actionId, opId);
+		}
+
+		// Deposit- op 1 is the current withdraw amount 1/5/10/x
+		if (currentBankModeSwap != BankSwapMode.OFF && currentBankModeSwap != BankSwapMode.SWAP_EXTRA_OP
+				&& menuEntryAdded.getType() == MenuAction.CC_OP.getId() && menuEntryAdded.getIdentifier() == 1
+				&& menuEntryAdded.getOption().startsWith("Withdraw")) {
+			boolean isChambersStorageUnit = widgetGroupId == WidgetID.CHAMBERS_OF_XERIC_STORAGE_UNIT_PRIVATE_GROUP_ID || widgetGroupId == WidgetID.CHAMBERS_OF_XERIC_STORAGE_UNIT_SHARED_GROUP_ID;
+			final int actionId = isChambersStorageUnit ? MenuAction.CC_OP.getId()
+					: currentBankModeSwap.getWithdrawMenuAction().getId();
+			final int opId = isChambersStorageUnit ? currentBankModeSwap.getWithdrawIdentifierChambersStorageUnit()
+					: currentBankModeSwap.getWithdrawIdentifier();
+			bankModeSwap(actionId, opId);
+		}
+	}
+
+	private void bankModeSwap(int entryTypeId, int entryIdentifier)
+	{
+		MenuEntry[] menuEntries = client.getMenuEntries();
+
+		for (int i = menuEntries.length - 1; i >= 0; --i)
+		{
+			MenuEntry entry = menuEntries[i];
+
+			if (entry.getType() == entryTypeId && entry.getIdentifier() == entryIdentifier)
+			{
+				// Raise the priority of the op so it doesn't get sorted later
+				entry.setType(MenuAction.CC_OP.getId());
+
+				menuEntries[i] = menuEntries[menuEntries.length - 1];
+				menuEntries[menuEntries.length - 1] = entry;
+
+				client.setMenuEntries(menuEntries);
+				break;
+			}
+		}
+	}
+
 }
 


### PR DESCRIPTION
Adds the option to assign a key for each menu entry on items in the bank, which swaps that entry when the key is held. This is like the regular menu entry swapper's bank swaps, but it allows each entry to have its own key instead of only allowing one entry to be swapped with shift.

I understand if using customizable hotkeys is too different from other menu entry swaps to be added to this plugin. Just figured I'd try here first before making a second menu entry swapping plugin.