### PR TITLE
Add Hosidius Mess take swap

### DIFF
--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
@@ -357,4 +357,15 @@ public interface MenuSwapperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+			keyName = "swapTakeLeftClick",
+			name = "Hosidius Mess Take",
+			description = "Change the left-click option on Hosidius Mess items",
+			section = objectSection
+	)
+	default TakeMode swapTakeLeftClick()
+	{
+		return TakeMode.TAKE1;
+	}
 }

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
@@ -138,7 +138,9 @@ public class MenuSwapperPlugin extends Plugin implements KeyListener
 			return;
 		}
 
-		if (option.equals("talk-to"))
+		if(option.equals("take") && target.startsWith("servery")){
+			swap(config.swapTakeLeftClick().getOption().toLowerCase(), option, target, index);
+		} else if (option.equals("talk-to"))
 		{
 			if (config.swapPlank() && target.equals("sawmill operator"))
 			{

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
@@ -138,9 +138,7 @@ public class MenuSwapperPlugin extends Plugin implements KeyListener
 			return;
 		}
 
-		if(option.equals("take") && target.startsWith("servery")){
-			swap(config.swapTakeLeftClick().getOption().toLowerCase(), option, target, index);
-		} else if (option.equals("talk-to"))
+		if (option.equals("talk-to"))
 		{
 			if (config.swapPlank() && target.equals("sawmill operator"))
 			{
@@ -284,6 +282,8 @@ public class MenuSwapperPlugin extends Plugin implements KeyListener
 		else if (config.swapStrayDog() && option.equals("shoo-away") && target.contains("stray dog"))
 		{
 			swap("pet", option, target, index);
+		} else if(option.equals("take") && (target.startsWith("servery") || target.equals("bowl") || target.equals("knife"))){
+			swap(config.swapTakeLeftClick().getOption().toLowerCase(), option, target, index);
 		}
 	}
 

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
@@ -282,7 +282,9 @@ public class MenuSwapperPlugin extends Plugin implements KeyListener
 		else if (config.swapStrayDog() && option.equals("shoo-away") && target.contains("stray dog"))
 		{
 			swap("pet", option, target, index);
-		} else if(option.equals("take") && (target.startsWith("servery") || target.equals("bowl") || target.equals("knife"))){
+		} 
+		else if(option.equals("take") && (target.startsWith("servery") || target.equals("bowl") || target.equals("knife")))
+		{
 			swap(config.swapTakeLeftClick().getOption().toLowerCase(), option, target, index);
 		}
 	}

--- a/src/main/java/io/ryoung/menuswapperextended/TakeMode.java
+++ b/src/main/java/io/ryoung/menuswapperextended/TakeMode.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020, Jaakko Sirén <https://github.com/Jaakkonen>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.ryoung.menuswapperextended;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TakeMode
+{
+    TAKE1("Take"),
+    TAKE5("Take-5"),
+    TAKE10("Take-10"),
+    TAKE50("Take-50"),
+    TAKEX("Take-X");
+
+    private final String option;
+
+    @Override
+    public String toString()
+    {
+        return option;
+    }
+}


### PR DESCRIPTION
Pretty minor qol change to hosidius mess.

This works as a generic Take swap if you just take out target checks, not sure if there would be anything rule breaking among all takes so I limited it to just hosidius mess to be on the safe side.
I'd imagine it'd be fine though as its pretty similar to the buy/sell hold-shift to swap in normal swapper.