### PR TITLE
refactor to use new swap style

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.36-SNAPSHOT'
+def runeLiteVersion = '1.7.6-SNAPSHOT'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -26,7 +26,7 @@ dependencies {
 }
 
 group = 'io.ryoung.menuswapperextended'
-version = '1.6'
+version = '1.7'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/io/ryoung/menuswapperextended/ArdougneCloakMode.java
+++ b/src/main/java/io/ryoung/menuswapperextended/ArdougneCloakMode.java
@@ -24,12 +24,13 @@
  */
 package io.ryoung.menuswapperextended;
 
+import java.util.function.Predicate;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum ArdougneCloakMode
+public enum ArdougneCloakMode implements SwapMode
 {
  	WEAR("Wear"),
 	MONASTERY_TELEPORT("Monastery Teleport"),
@@ -41,5 +42,11 @@ public enum ArdougneCloakMode
 	public String toString()
 	{
 		return option;
+	}
+
+	@Override
+	public Predicate<String> checkTarget()
+	{
+		return target -> target.startsWith("ardougne cloak") || target.startsWith("ardougne max cape");
 	}
 }

--- a/src/main/java/io/ryoung/menuswapperextended/CharterShipsMode.java
+++ b/src/main/java/io/ryoung/menuswapperextended/CharterShipsMode.java
@@ -24,23 +24,38 @@
  */
 package io.ryoung.menuswapperextended;
 
+import java.util.function.Predicate;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum CharterShipsMode
+public enum CharterShipsMode implements SwapMode
 {
-	TALK("Talk-To"),
-	TRADE("Trade"),
-	CHARTER("Charter"),
-	LAST_DESTINATION("Last Destination");
+	TALK("Talk-To", "talk-to"),
+	TRADE("Trade", "trade"),
+	CHARTER("Charter", "charter"),
+	LAST_DESTINATION("Last Destination", "charter-to");
 
+
+	private final String name;
 	private final String option;
 
 	@Override
 	public String toString()
 	{
-		return option;
+		return name;
+	}
+
+	@Override
+	public boolean strict()
+	{
+		return this != CharterShipsMode.LAST_DESTINATION;
+	}
+
+	@Override
+	public Predicate<String> checkTarget()
+	{
+		return target -> target.startsWith("trader crewmember");
 	}
 }

--- a/src/main/java/io/ryoung/menuswapperextended/DesertAmuletMode.java
+++ b/src/main/java/io/ryoung/menuswapperextended/DesertAmuletMode.java
@@ -24,12 +24,13 @@
  */
 package io.ryoung.menuswapperextended;
 
+import java.util.function.Predicate;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum DesertAmuletMode
+public enum DesertAmuletMode implements SwapMode
 {
 	WEAR("Wear"),
 	NARDAH("Nardah"),
@@ -41,5 +42,17 @@ public enum DesertAmuletMode
 	public String toString()
 	{
 		return option;
+	}
+
+	@Override
+	public boolean checkShift()
+	{
+		return true;
+	}
+
+	@Override
+	public Predicate<String> checkTarget()
+	{
+		return target -> target.startsWith("desert amulet");
 	}
 }

--- a/src/main/java/io/ryoung/menuswapperextended/DrakansMedallionMode.java
+++ b/src/main/java/io/ryoung/menuswapperextended/DrakansMedallionMode.java
@@ -24,12 +24,13 @@
  */
 package io.ryoung.menuswapperextended;
 
+import java.util.function.Predicate;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum DrakansMedallionMode
+public enum DrakansMedallionMode implements SwapMode
 {
 	WEAR("Wear"),
 	VER_SINHAZA("Ver Sinhaza"),
@@ -41,5 +42,17 @@ public enum DrakansMedallionMode
 	public String toString()
 	{
 		return option;
+	}
+
+	@Override
+	public boolean checkShift()
+	{
+		return true;
+	}
+
+	@Override
+	public Predicate<String> checkTarget()
+	{
+		return target -> target.startsWith("drakan's medallion");
 	}
 }

--- a/src/main/java/io/ryoung/menuswapperextended/KaramjaGlovesMode.java
+++ b/src/main/java/io/ryoung/menuswapperextended/KaramjaGlovesMode.java
@@ -24,12 +24,13 @@
  */
 package io.ryoung.menuswapperextended;
 
+import java.util.function.Predicate;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum KaramjaGlovesMode
+public enum KaramjaGlovesMode implements SwapMode
 {
 	WEAR("Wear"),
 	GEM_MINE("Gem Mine"),
@@ -41,5 +42,17 @@ public enum KaramjaGlovesMode
 	public String toString()
 	{
 		return option;
+	}
+
+	@Override
+	public boolean checkShift()
+	{
+		return true;
+	}
+
+	@Override
+	public Predicate<String> checkTarget()
+	{
+		return target -> target.startsWith("karamja gloves");
 	}
 }

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
@@ -128,17 +128,6 @@ public interface MenuSwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "swapSendParcel",
-		name = "Send Parcel",
-		description = "Swap Talk-To to with Send-Parcel for Rionasta at the Tai Bwo Wannai village.",
-		section = npcSection
-	)
-	default boolean swapSendParcel()
-	{
-		return false;
-	}
-
-	@ConfigItem(
 		keyName = "swapTeleportToDestination",
 		name = "Obelisk",
 		description = "Swap Activate with Teleport to Destination or Set Destination",
@@ -156,17 +145,6 @@ public interface MenuSwapperConfig extends Config
 		section = npcSection
 	)
 	default boolean swapZulrahCollect()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		keyName = "decant",
-		name = "Decant",
-		description = "Decant for e.g. Bob Barter",
-		section = npcSection
-	)
-	default boolean swapDecant()
 	{
 		return false;
 	}
@@ -196,7 +174,7 @@ public interface MenuSwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapStore",
 		name = "Builders Store",
-		description = "Swap Trade-General-Store with Trade-Builders-Store for the NPC Razmire Keelgan",
+		description = "Swap Talk-to with Trade-Builders-Store for the NPC Razmire Keelgan",
 		section = npcSection
 	)
 	default boolean swapStore()
@@ -348,9 +326,9 @@ public interface MenuSwapperConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "swapStrayDog",
-			name = "Stray dog",
-			description = "Swaps Shoo-away with Pet for Stray dogs",
+		keyName = "swapStrayDog",
+		name = "Stray dog",
+		description = "Swaps Shoo-away with Pet for Stray dogs",
 		section = npcSection
 	)
 	default boolean swapStrayDog()

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
@@ -112,37 +112,25 @@ public class MenuSwapperPlugin extends Plugin
 		swap("talk-to", "trade-builders-store", config::swapStore);
 		swap("talk-to", "give-sword", config::swapGiveSword);
 		swap("talk-to", "spellbook", config::swapTyssSpellbook);
-		swap("talk-to", "zahur", "clean", () -> config.swapZahur() == ZahurMode.CLEAN);
-		swap("talk-to", "zahur", "decant", () -> config.swapZahur() == ZahurMode.DECANT);
-		swap("talk-to", "zahur", "make unfinished potion(s)", () -> config.swapZahur() == ZahurMode.MAKE_POTION);
-		swapContains("talk-to", target -> target.startsWith("trader crewmember"), "trade", () -> !shiftModifier() && config.swapTraderCrewmemberLeftClick() == CharterShipsMode.TRADE);
-		swap("talk-to", "charter", () -> !shiftModifier() && config.swapTraderCrewmemberLeftClick() == CharterShipsMode.CHARTER);
-		swap("talk-to",  "charter-to", () -> !shiftModifier() && config.swapTraderCrewmemberLeftClick() == CharterShipsMode.LAST_DESTINATION);
+
+		swapMode("talk-to", ZahurMode.class, config::swapZahur);
+		swapMode("talk-to", CharterShipsMode.class, config::swapTraderCrewmemberLeftClick);
 
 		swap("wear", "tele to poh", () -> !shiftModifier() && config.swapConsCape());
-		swap("wear", "gem mine", () -> !shiftModifier() && config.swapKaramjaGlovesLeftClick() == KaramjaGlovesMode.GEM_MINE);
-		swap("wear", "duradel", () -> !shiftModifier() && config.swapKaramjaGlovesLeftClick() == KaramjaGlovesMode.DURADEL);
-		swap("wear", "nardah", () -> !shiftModifier() && config.swapDesertAmuletLeftClick() == DesertAmuletMode.NARDAH);
-		swap("wear", "kalphite cave", () -> !shiftModifier() && config.swapDesertAmuletLeftClick() == DesertAmuletMode.KALPHITE_CAVE);
-		swap("wear", "ecto teleport", () -> !shiftModifier() && config.swapMorytaniaLegsLeftClick() == MorytaniaLegsMode.ECTO_TELEPORT);
-		swap("wear", "burgh teleport", () -> !shiftModifier() && config.swapMorytaniaLegsLeftClick() == MorytaniaLegsMode.BURGH_TELEPORT);
-		swap("wear", "monastery teleport", () -> !shiftModifier() && config.swapArdougneCloakLeftClick() == ArdougneCloakMode.MONASTERY_TELEPORT);
-		swap("wear", "farm teleport", () -> !shiftModifier() && config.swapArdougneCloakLeftClick() == ArdougneCloakMode.FARM_TELEPORT);
-		swap("wear", "ver sinhaza", () -> !shiftModifier() && config.swapDrakansMedallionLeftClick() == DrakansMedallionMode.VER_SINHAZA);
-		swap("wear", "darkmeyer", () -> !shiftModifier() && config.swapDrakansMedallionLeftClick() == DrakansMedallionMode.DARKMEYER);
-		swap("wield", "jalsavrah", () -> !shiftModifier() && config.swapPharaohSceptreLeftClick() == PharaohSceptreMode.JALSAVRAH);
-		swap("wield", "jaleustrophos", () -> !shiftModifier() && config.swapPharaohSceptreLeftClick() == PharaohSceptreMode.JALEUSTROPHOS);
-		swap("wield", "jaldraocht", () -> !shiftModifier() && config.swapPharaohSceptreLeftClick() == PharaohSceptreMode.JALDRAOCHT);
 
-		swap("activate", "teleport to destination", () -> config.swapTeleportToDestination() == ObeliskMode.TELEPORT_TO_DESTINATION);
-		swap("activate", "set destination", () -> config.swapTeleportToDestination() == ObeliskMode.SET_DESTINATION);
+		swapMode("wear", KaramjaGlovesMode.class, config::swapKaramjaGlovesLeftClick);
+		swapMode("wear", DesertAmuletMode.class, config::swapDesertAmuletLeftClick);
+		swapMode("wear", MorytaniaLegsMode.class, config::swapMorytaniaLegsLeftClick);
+		swapMode("wear", ArdougneCloakMode.class, config::swapArdougneCloakLeftClick);
+		swapMode("wear", DrakansMedallionMode.class, config::swapDrakansMedallionLeftClick);
+		swapMode("wield", PharaohSceptreMode.class, config::swapPharaohSceptreLeftClick);
+		swapMode("activate", ObeliskMode.class, config::swapTeleportToDestination);
 
 		swap("ardougne", "edgeville", config::swapWildernessLever);
 
 		swapContains("attack", target -> target.startsWith("hoop snake"), "stun", config::swapStun);
-		swap("cast", "standard", () -> !shiftModifier() && config.swapSpellbookSwapLeftClick() == SpellbookSwapMode.STANDARD);
-		swap("cast", "ancient", () -> !shiftModifier() && config.swapSpellbookSwapLeftClick() == SpellbookSwapMode.ANCIENT);
-		swap("cast", "arceuus", () -> !shiftModifier() && config.swapSpellbookSwapLeftClick() == SpellbookSwapMode.ARCEUUS);
+
+		swapMode("cast", SpellbookSwapMode.class, config::swapSpellbookSwapLeftClick);
 
 		swap("open (normal)", "open (private)", config::swapGodWarsDoor);
 		swap("close", "search", config::swapSearch);
@@ -150,6 +138,20 @@ public class MenuSwapperPlugin extends Plugin
 		swap("shoo-away", "pet", config::swapStrayDog);
 		swap("standard", "slayer", config::dagganothKingsLadder);
 		swap("lletya", "prifddinas", () -> !shiftModifier() && config.swapTeleCrystal());
+	}
+
+	private <T extends Enum<?> & SwapMode> void swapMode(String option, Class<T> mode, Supplier<T> enumGet)
+	{
+		for (T e : mode.getEnumConstants())
+		{
+			swaps.put(option, new Swap(
+				alwaysTrue(),
+				e.checkTarget(),
+				e.getOption().toLowerCase(),
+				() -> (!e.checkShift() || (e.checkShift() && !shiftModifier())) & e == enumGet.get(),
+				e.strict()
+			));
+		}
 	}
 
 	private void swap(String option, String swappedOption, Supplier<Boolean> enabled)

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
@@ -1,5 +1,9 @@
 /*
  * Copyright (c) 2019, Ron Young <https://github.com/raiyni>
+ * Copyright (c) 2021, Truth Forger <https://github.com/Blackberry0Pie>
+ * Copyright (c) 2018, Adam <Adam@sigterm.info>
+ * Copyright (c) 2018, Kamiel
+ * Copyright (c) 2019, Rami <https://github.com/Rami-J>
  * All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -25,35 +29,96 @@
 
 package io.ryoung.menuswapperextended;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.Multimap;
 import com.google.inject.Provides;
-import java.awt.event.KeyEvent;
+
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 import javax.inject.Inject;
+
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import net.runelite.api.ItemComposition;
+import net.runelite.api.KeyCode;
 import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.NPC;
 import net.runelite.api.events.ClientTick;
-import net.runelite.api.events.FocusChanged;
+import net.runelite.api.events.MenuOpened;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.events.PostItemComposition;
+import net.runelite.api.events.WidgetMenuOptionClicked;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
-import net.runelite.client.input.KeyListener;
+import net.runelite.client.events.ConfigChanged;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.game.ItemVariationMapping;
 import net.runelite.client.input.KeyManager;
+import net.runelite.client.menus.MenuManager;
+import net.runelite.client.menus.WidgetMenuOption;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.menuentryswapper.MenuEntrySwapperConfig;
 import net.runelite.client.util.Text;
+import org.apache.commons.lang3.ArrayUtils;
+
+import static com.google.common.base.Predicates.alwaysTrue;
+import static com.google.common.base.Predicates.equalTo;
 
 @Slf4j
 @PluginDescriptor(
 	name = "Menu Swapper Extended"
 )
-public class MenuSwapperPlugin extends Plugin implements KeyListener
+public class MenuSwapperPlugin extends Plugin
 {
+	private static final String CONFIGURE = "Configure";
+	private static final String SAVE = "Save";
+	private static final String RESET = "Reset";
+	private static final String MENU_TARGET = "Shift-click";
+
+	private static final String SHIFTCLICK_CONFIG_GROUP = "shiftclick";
+	private static final String ITEM_KEY_PREFIX = "item_";
+
+	private static final WidgetMenuOption FIXED_INVENTORY_TAB_CONFIGURE = new WidgetMenuOption(CONFIGURE,
+		MENU_TARGET, WidgetInfo.FIXED_VIEWPORT_INVENTORY_TAB);
+
+	private static final WidgetMenuOption FIXED_INVENTORY_TAB_SAVE = new WidgetMenuOption(SAVE,
+		MENU_TARGET, WidgetInfo.FIXED_VIEWPORT_INVENTORY_TAB);
+
+	private static final WidgetMenuOption RESIZABLE_INVENTORY_TAB_CONFIGURE = new WidgetMenuOption(CONFIGURE,
+		MENU_TARGET, WidgetInfo.RESIZABLE_VIEWPORT_INVENTORY_TAB);
+
+	private static final WidgetMenuOption RESIZABLE_INVENTORY_TAB_SAVE = new WidgetMenuOption(SAVE,
+		MENU_TARGET, WidgetInfo.RESIZABLE_VIEWPORT_INVENTORY_TAB);
+
+	private static final WidgetMenuOption RESIZABLE_BOTTOM_LINE_INVENTORY_TAB_CONFIGURE = new WidgetMenuOption(CONFIGURE,
+		MENU_TARGET, WidgetInfo.RESIZABLE_VIEWPORT_BOTTOM_LINE_INVENTORY_TAB);
+
+	private static final WidgetMenuOption RESIZABLE_BOTTOM_LINE_INVENTORY_TAB_SAVE = new WidgetMenuOption(SAVE,
+		MENU_TARGET, WidgetInfo.RESIZABLE_VIEWPORT_BOTTOM_LINE_INVENTORY_TAB);
+
+	private static final Set<MenuAction> ITEM_MENU_TYPES = ImmutableSet.of(
+		MenuAction.ITEM_FIRST_OPTION,
+		MenuAction.ITEM_SECOND_OPTION,
+		MenuAction.ITEM_THIRD_OPTION,
+		MenuAction.ITEM_FOURTH_OPTION,
+		MenuAction.ITEM_FIFTH_OPTION,
+		MenuAction.EXAMINE_ITEM,
+		MenuAction.ITEM_USE
+	);
+
 	private static final Set<MenuAction> NPC_MENU_TYPES = ImmutableSet.of(
 		MenuAction.NPC_FIRST_OPTION,
 		MenuAction.NPC_SECOND_OPTION,
@@ -66,12 +131,28 @@ public class MenuSwapperPlugin extends Plugin implements KeyListener
 	private Client client;
 
 	@Inject
+	private ClientThread clientThread;
+
+	@Inject
 	private MenuSwapperConfig config;
+
+	@Inject
+	private ConfigManager configManager;
+
+	@Inject
+	private MenuManager menuManager;
+
+	@Inject
+	private ItemManager itemManager;
 
 	@Inject
 	private KeyManager keyManager;
 
-	private boolean shiftHeld = false;
+	@Getter
+	private boolean configuringShiftClick = false;
+
+	private final Multimap<String, Swap> swaps = LinkedHashMultimap.create();
+	private final ArrayListMultimap<String, Integer> optionIndexes = ArrayListMultimap.create();
 
 	@Provides
 	MenuSwapperConfig provideConfig(ConfigManager configManager)
@@ -82,20 +163,331 @@ public class MenuSwapperPlugin extends Plugin implements KeyListener
 	@Override
 	public void startUp()
 	{
-		shiftHeld = false;
-		keyManager.registerKeyListener(this);
+		if (configManager.getConfiguration(MenuEntrySwapperConfig.GROUP, "shiftClickCustomization").equals("true"))
+		{
+			enableCustomization();
+		}
+
+		setupSwaps();
 	}
 
 	@Override
 	public void shutDown()
 	{
-		shiftHeld = false;
-		keyManager.unregisterKeyListener(this);
+		disableCustomization();
+		swaps.clear();
 	}
 
-	private final ArrayListMultimap<String, Integer> optionIndexes = ArrayListMultimap.create();
+	@VisibleForTesting
+	void setupSwaps()
+	{
+		swap("talk-to", "buy-plank", config::swapPlank);
+		swap("talk-to", "claim", config::claimDynamite);
+		swap("talk-to", "story", config::swapMinigames);
+		swap("talk-to", "dream", config::swapMinigames);
+		swap("talk-to", "escort", config::swapMinigames);
+		swap("talk-to", "join", config::swapMinigames);
+		swap("talk-to", "priestess zul-gwenwynig", "collect", config::swapZulrahCollect);
+		swap("talk-to", "trade-builders-store", config::swapStore);
+		swap("talk-to", "give-sword", config::swapGiveSword);
+		swap("talk-to", "spellbook", config::swapTyssSpellbook);
+		swap("talk-to", "zahur", "clean", () -> config.swapZahur() == ZahurMode.CLEAN);
+		swap("talk-to", "zahur", "decant", () -> config.swapZahur() == ZahurMode.DECANT);
+		swap("talk-to", "zahur", "make unfinished potion(s)", () -> config.swapZahur() == ZahurMode.MAKE_POTION);
 
-	@Subscribe(priority = 10)
+		swap("wear", "tele to poh", () -> !shiftModifier() && config.swapConsCape());
+		swap("wear", "gem mine", () -> !shiftModifier() && config.swapKaramjaGlovesLeftClick() == KaramjaGlovesMode.GEM_MINE);
+		swap("wear", "duradel", () -> !shiftModifier() && config.swapKaramjaGlovesLeftClick() == KaramjaGlovesMode.DURADEL);
+		swap("wear", "nardah", () -> !shiftModifier() && config.swapDesertAmuletLeftClick() == DesertAmuletMode.NARDAH);
+		swap("wear", "kalphite cave", () -> !shiftModifier() && config.swapDesertAmuletLeftClick() == DesertAmuletMode.KALPHITE_CAVE);
+		swap("wear", "ecto teleport", () -> !shiftModifier() && config.swapMorytaniaLegsLeftClick() == MorytaniaLegsMode.ECTO_TELEPORT);
+		swap("wear", "burgh teleport", () -> !shiftModifier() && config.swapMorytaniaLegsLeftClick() == MorytaniaLegsMode.BURGH_TELEPORT);
+		swap("wear", "monastery teleport", () -> !shiftModifier() && config.swapArdougneCloakLeftClick() == ArdougneCloakMode.MONASTERY_TELEPORT);
+		swap("wear", "farm teleport", () -> !shiftModifier() && config.swapArdougneCloakLeftClick() == ArdougneCloakMode.FARM_TELEPORT);
+		swap("wear", "ver sinhaza", () -> !shiftModifier() && config.swapDrakansMedallionLeftClick() == DrakansMedallionMode.VER_SINHAZA);
+		swap("wear", "darkmeyer", () -> !shiftModifier() && config.swapDrakansMedallionLeftClick() == DrakansMedallionMode.DARKMEYER);
+		swap("wield", "jalsavrah", () -> !shiftModifier() && config.swapPharaohSceptreLeftClick() == PharaohSceptreMode.JALSAVRAH);
+		swap("wield", "jaleustrophos", () -> !shiftModifier() && config.swapPharaohSceptreLeftClick() == PharaohSceptreMode.JALEUSTROPHOS);
+		swap("wield", "jaldraocht", () -> !shiftModifier() && config.swapPharaohSceptreLeftClick() == PharaohSceptreMode.JALDRAOCHT);
+
+		swap("activate", "teleport to destination", () -> config.swapTeleportToDestination() == ObeliskMode.TELEPORT_TO_DESTINATION);
+		swap("activate", "set destination", () -> config.swapTeleportToDestination() == ObeliskMode.SET_DESTINATION);
+		swap("ardougne", "edgeville", config::swapWildernessLever);
+		swapContains("attack", target -> target.startsWith("hoop snake"), "stun", config::swapStun);
+		swap("cast", "standard", () -> !shiftModifier() && config.swapSpellbookSwapLeftClick() == SpellbookSwapMode.STANDARD);
+		swap("cast", "ancient", () -> !shiftModifier() && config.swapSpellbookSwapLeftClick() == SpellbookSwapMode.ANCIENT);
+		swap("cast", "arceuus", () -> !shiftModifier() && config.swapSpellbookSwapLeftClick() == SpellbookSwapMode.ARCEUUS);
+		swap("open (normal)", "open (private)", config::swapGodWarsDoor);
+		swap("close", "search", config::swapSearch);
+		swap("shut", "search", config::swapSearch);
+		swap("shoo-away", "pet", config::swapStrayDog);
+		swap("standard", "slayer", config::dagganothKingsLadder);
+		swap("talk-to", "trade", () -> !shiftModifier() && config.swapTraderCrewmemberLeftClick() == CharterShipsMode.TRADE);
+		swap("talk-to", "charter", () -> !shiftModifier() && config.swapTraderCrewmemberLeftClick() == CharterShipsMode.CHARTER);
+		swapContains("talk-to", alwaysTrue(), "charter-to", () -> !shiftModifier() && config.swapTraderCrewmemberLeftClick() == CharterShipsMode.LAST_DESTINATION);
+		swap("lletya", "prifddinas", () -> !shiftModifier() && config.swapTeleCrystal());
+	}
+
+	private void swap(String option, String swappedOption, Supplier<Boolean> enabled)
+	{
+		swap(option, alwaysTrue(), swappedOption, enabled);
+	}
+
+	private void swap(String option, String target, String swappedOption, Supplier<Boolean> enabled)
+	{
+		swap(option, equalTo(target), swappedOption, enabled);
+	}
+
+	private void swap(String option, Predicate<String> targetPredicate, String swappedOption, Supplier<Boolean> enabled)
+	{
+		swaps.put(option, new Swap(alwaysTrue(), targetPredicate, swappedOption, enabled, true));
+	}
+
+	private void swapContains(String option, Predicate<String> targetPredicate, String swappedOption, Supplier<Boolean> enabled)
+	{
+		swaps.put(option, new Swap(alwaysTrue(), targetPredicate, swappedOption, enabled, false));
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (event.getGroup().equals(MenuEntrySwapperConfig.GROUP) && event.getKey().equals("shiftClickCustomization"))
+		{
+			if (configManager.getConfiguration(MenuEntrySwapperConfig.GROUP, "shiftClickCustomization").equals("true"))
+			{
+				enableCustomization();
+			}
+			else
+			{
+				disableCustomization();
+			}
+		}
+		else if (event.getGroup().equals(SHIFTCLICK_CONFIG_GROUP) && event.getKey().startsWith(ITEM_KEY_PREFIX))
+		{
+			clientThread.invoke(this::resetItemCompositionCache);
+		}
+	}
+
+	private void resetItemCompositionCache()
+	{
+		itemManager.invalidateItemCompositionCache();
+		client.getItemCompositionCache().reset();
+	}
+
+	private Integer getSwapConfig(int itemId)
+	{
+		itemId = ItemVariationMapping.map(itemId);
+		String config = configManager.getConfiguration(SHIFTCLICK_CONFIG_GROUP, ITEM_KEY_PREFIX + itemId);
+		if (config == null || config.isEmpty())
+		{
+			return null;
+		}
+
+		return Integer.parseInt(config);
+	}
+
+	private void setSwapConfig(int itemId, int index)
+	{
+		itemId = ItemVariationMapping.map(itemId);
+		configManager.setConfiguration(SHIFTCLICK_CONFIG_GROUP, ITEM_KEY_PREFIX + itemId, index);
+	}
+
+	private void unsetSwapConfig(int itemId)
+	{
+		itemId = ItemVariationMapping.map(itemId);
+		configManager.unsetConfiguration(SHIFTCLICK_CONFIG_GROUP, ITEM_KEY_PREFIX + itemId);
+	}
+
+	private void enableCustomization()
+	{
+		refreshShiftClickCustomizationMenus();
+		// set shift click action index on the item compositions
+		clientThread.invoke(this::resetItemCompositionCache);
+	}
+
+	private void disableCustomization()
+	{
+		removeShiftClickCustomizationMenus();
+		configuringShiftClick = false;
+		// flush item compositions to reset the shift click action index
+		clientThread.invoke(this::resetItemCompositionCache);
+	}
+
+	@Subscribe
+	public void onWidgetMenuOptionClicked(WidgetMenuOptionClicked event)
+	{
+		if (event.getWidget() == WidgetInfo.FIXED_VIEWPORT_INVENTORY_TAB
+				|| event.getWidget() == WidgetInfo.RESIZABLE_VIEWPORT_INVENTORY_TAB
+				|| event.getWidget() == WidgetInfo.RESIZABLE_VIEWPORT_BOTTOM_LINE_INVENTORY_TAB)
+		{
+			configuringShiftClick = event.getMenuOption().equals(CONFIGURE) && Text.removeTags(event.getMenuTarget()).equals(MENU_TARGET);
+			refreshShiftClickCustomizationMenus();
+		}
+	}
+
+	@Subscribe
+	public void onMenuOpened(MenuOpened event)
+	{
+		if (!configuringShiftClick)
+		{
+			return;
+		}
+
+		MenuEntry firstEntry = event.getFirstEntry();
+		if (firstEntry == null)
+		{
+			return;
+		}
+
+		int widgetId = firstEntry.getParam1();
+		if (widgetId != WidgetInfo.INVENTORY.getId())
+		{
+			return;
+		}
+
+		int itemId = firstEntry.getIdentifier();
+		if (itemId == -1)
+		{
+			return;
+		}
+
+		ItemComposition itemComposition = itemManager.getItemComposition(itemId);
+		MenuAction shiftClickAction = MenuAction.ITEM_USE;
+		final int shiftClickActionIndex = itemComposition.getShiftClickActionIndex();
+
+		if (shiftClickActionIndex >= 0)
+		{
+			shiftClickAction = MenuAction.of(MenuAction.ITEM_FIRST_OPTION.getId() + shiftClickActionIndex);
+		}
+
+		MenuEntry[] entries = event.getMenuEntries();
+
+		for (MenuEntry entry : entries)
+		{
+			final MenuAction menuAction = MenuAction.of(entry.getType());
+
+			if (ITEM_MENU_TYPES.contains(menuAction) && entry.getIdentifier() == itemId)
+			{
+				entry.setType(MenuAction.RUNELITE.getId());
+
+				if (shiftClickAction == menuAction)
+				{
+					entry.setOption("* " + entry.getOption());
+				}
+			}
+		}
+
+		final MenuEntry resetShiftClickEntry = new MenuEntry();
+		resetShiftClickEntry.setOption(RESET);
+		resetShiftClickEntry.setTarget(MENU_TARGET);
+		resetShiftClickEntry.setIdentifier(itemId);
+		resetShiftClickEntry.setParam1(widgetId);
+		resetShiftClickEntry.setType(MenuAction.RUNELITE.getId());
+		client.setMenuEntries(ArrayUtils.addAll(entries, resetShiftClickEntry));
+	}
+
+	@Subscribe
+	public void onMenuOptionClicked(MenuOptionClicked event)
+	{
+		if (event.getMenuAction() != MenuAction.RUNELITE || event.getWidgetId() != WidgetInfo.INVENTORY.getId())
+		{
+			return;
+		}
+
+		int itemId = event.getId();
+
+		if (itemId == -1)
+		{
+			return;
+		}
+
+		String option = event.getMenuOption();
+		String target = event.getMenuTarget();
+		ItemComposition itemComposition = itemManager.getItemComposition(itemId);
+
+		if (option.equals(RESET) && target.equals(MENU_TARGET))
+		{
+			unsetSwapConfig(itemId);
+			return;
+		}
+
+		if (!itemComposition.getName().equals(Text.removeTags(target)))
+		{
+			return;
+		}
+
+		if (option.equals("Use")) //because "Use" is not in inventoryActions
+		{
+			setSwapConfig(itemId, -1);
+		}
+		else
+		{
+			String[] inventoryActions = itemComposition.getInventoryActions();
+
+			for (int index = 0; index < inventoryActions.length; index++)
+			{
+				if (option.equals(inventoryActions[index]))
+				{
+					setSwapConfig(itemId, index);
+					break;
+				}
+			}
+		}
+	}
+
+	private void swapMenuEntry(int index, MenuEntry menuEntry)
+	{
+		final int eventId = menuEntry.getIdentifier();
+		final MenuAction menuAction = MenuAction.of(menuEntry.getType());
+		final String option = Text.removeTags(menuEntry.getOption()).toLowerCase();
+		final String target = Text.removeTags(menuEntry.getTarget()).toLowerCase();
+		final NPC hintArrowNpc = client.getHintArrowNpc();
+
+		if (hintArrowNpc != null
+			&& hintArrowNpc.getIndex() == eventId
+			&& NPC_MENU_TYPES.contains(menuAction))
+		{
+			return;
+		}
+
+		if (shiftModifier() && (menuAction == MenuAction.ITEM_FIRST_OPTION
+			|| menuAction == MenuAction.ITEM_SECOND_OPTION
+			|| menuAction == MenuAction.ITEM_THIRD_OPTION
+			|| menuAction == MenuAction.ITEM_FOURTH_OPTION
+			|| menuAction == MenuAction.ITEM_FIFTH_OPTION
+			|| menuAction == MenuAction.ITEM_USE))
+		{
+			// Special case use shift click due to items not actually containing a "Use" option, making
+			// the client unable to perform the swap itself.
+			if (configManager.getConfiguration(MenuEntrySwapperConfig.GROUP, "shiftClickCustomization").equals("true") && !option.equals("use"))
+			{
+				Integer customOption = getSwapConfig(eventId);
+
+				if (customOption != null && customOption == -1)
+				{
+					swap("use", target, index, true);
+				}
+			}
+
+			// don't perform swaps on items when shift is held; instead prefer the client menu swap, which
+			// we may have overwrote
+			return;
+		}
+
+		Collection<Swap> swaps = this.swaps.get(option);
+		for (Swap swap : swaps)
+		{
+			if (swap.getTargetPredicate().test(target) && swap.getEnabled().get())
+			{
+				if (swap(swap.getSwappedOption(), target, index, swap.isStrict()))
+				{
+					break;
+				}
+			}
+		}
+	}
+
+	@Subscribe
 	public void onClientTick(ClientTick clientTick)
 	{
 		// The menu is not rebuilt when it is open, so don't swap or else it will
@@ -124,228 +516,39 @@ public class MenuSwapperPlugin extends Plugin implements KeyListener
 		}
 	}
 
-	private void swapMenuEntry(int index, MenuEntry menuEntry)
+	@Subscribe
+	public void onPostItemComposition(PostItemComposition event)
 	{
-		final int eventId = menuEntry.getIdentifier();
-		final String option = Text.removeTags(menuEntry.getOption()).toLowerCase();
-		final String target = Text.removeTags(menuEntry.getTarget()).toLowerCase();
-		final NPC hintArrowNpc = client.getHintArrowNpc();
-
-		if (hintArrowNpc != null
-			&& hintArrowNpc.getIndex() == eventId
-			&& NPC_MENU_TYPES.contains(MenuAction.of(menuEntry.getType())))
+		if (configManager.getConfiguration(MenuEntrySwapperConfig.GROUP, "shiftClickCustomization").equals("false"))
 		{
+			// since shift-click is done by the client we have to check if our shift click customization is on
+			// prior to altering the item shift click action index.
 			return;
 		}
 
-		if (option.equals("talk-to"))
-		{
-			if (config.swapPlank() && target.equals("sawmill operator"))
-			{
-				swap("buy-plank", option, target, index);
-			}
+		ItemComposition itemComposition = event.getItemComposition();
+		Integer option = getSwapConfig(itemComposition.getId());
 
-			if (config.claimDynamite() && target.contains("thirus"))
-			{
-				swap("claim", option, target, index);
-			}
-
-			if (config.swapMinigames())
-			{
-				swap("story", option, target, index);
-				swap("start-minigame", option, target, index);
-				swap("dream", option, target, index);
-				swap("escort", option, target, index);
-				swap("join", option, target, index);
-			}
-
-			if (config.swapSendParcel())
-			{
-				swap("send-parcel", option, target, index);
-			}
-
-			if (config.swapZulrahCollect() && target.equals("priestess zul-gwenwynig"))
-			{
-				swap("collect", option, target, index);
-			}
-
-			if (config.swapStore())
-			{
-				swap("trade-builders-store", option, target, index);
-			}
-
-			if (config.swapGiveSword())
-			{
-				swap("give-sword", option, target, index);
-			}
-
-			if (config.swapTyssSpellbook())
-			{
-				swap("spellbook", option, target, index);
-			}
-		}
-		else if (!shiftHeld && option.equals("wear"))
+		if (option != null)
 		{
-			if (config.swapConsCape() && (target.startsWith("construct. cape")))
-			{
-				swap("tele to poh", option, target, index);
-			}
-			else if (target.startsWith("karamja gloves"))
-			{
-				swap(config.swapKaramjaGlovesLeftClick().getOption().toLowerCase(), option, target, index);
-			}
-			else if (target.startsWith("desert amulet"))
-			{
-				swap(config.swapDesertAmuletLeftClick().getOption().toLowerCase(), option, target, index);
-			}
-			else if (target.startsWith("morytania legs"))
-			{
-				swap(config.swapMorytaniaLegsLeftClick().getOption().toLowerCase(), option, target, index);
-			}
-			else if (target.startsWith("ardougne cloak") || target.startsWith("ardougne max cape"))
-			{
-				swap(config.swapArdougneCloakLeftClick().getOption().toLowerCase(), option, target, index);
-			}
-			else if (target.startsWith("drakan's medallion"))
-			{
-				swap(config.swapDrakansMedallionLeftClick().getOption().toLowerCase(), option, target, index);
-			}
-		}
-		else if (option.equals("attack"))
-		{
-			if (config.swapStun() && target.contains("hoop snake"))
-			{
-				swap("stun", option, target, index);
-			}
-		}
-		else if (config.swapSearch() && (option.equals("close") || option.equals("shut")))
-		{
-			swap("search", option, target, index);
-		}
-		else if (config.swapWildernessLever() && option.equals("ardougne") && target.equals("lever"))
-		{
-			swap("edgeville", option, target, index);
-		}
-		else if (target.equals("obelisk"))
-		{
-			switch (config.swapTeleportToDestination())
-			{
-				case SET_DESTINATION:
-					swap("set destination", option, target, index);
-					break;
-				case TELEPORT_TO_DESTINATION:
-					swap("teleport to destination", option, target, index);
-					break;
-			}
-		}
-		else if (config.swapDecant() && target.contains("bob barter"))
-		{
-			swap("decant", option, target, index);
-		}
-		else if (target.equals("zahur"))
-		{
-			swap(config.swapZahur().getOption().toLowerCase(), option, target, index);
-		}
-		else if (config.dagganothKingsLadder() && option.equals("standard") && target.contains("kings' ladder"))
-		{
-			swap("slayer", option, target, index);
-		}
-		else if (!shiftHeld && config.swapTeleCrystal() && option.equals("lletya"))
-		{
-			swap("prifddinas", option, target, index);
-		}
-		else if (!shiftHeld && target.startsWith("pharaoh's sceptre") && option.equals("wield"))
-		{
-			swap(config.swapPharaohSceptreLeftClick().getOption().toLowerCase(), option, target, index);
-		}
-		else if (!shiftHeld && target.startsWith("trader crewmember"))
-		{
-			CharterShipsMode configOption = config.swapTraderCrewmemberLeftClick();
-			if (configOption == CharterShipsMode.LAST_DESTINATION)
-			{
-				swap("charter-to", option, target, index, false);
-			}
-			else
-			{
-				// NOTE: Selecting Talk-To conflicts with Runelites own Menu entry swappers options "Trade" and "Travel"
-				swap(configOption.getOption().toLowerCase(), option, target, index);
-			}
-		}
-		else if (!shiftHeld && target.startsWith("spellbook swap") && option.equals("cast"))
-		{
-			swap(config.swapSpellbookSwapLeftClick().getOption().toLowerCase(), option, target, index);
-		}
-		else if (config.swapGodWarsDoor() && option.equals("open (normal)") && target.contains("big door"))
-		{
-			swap("open (private)", option, target, index);
-		}
-		else if (config.swapStrayDog() && option.equals("shoo-away") && target.contains("stray dog"))
-		{
-			swap("pet", option, target, index);
+			itemComposition.setShiftClickActionIndex(option);
 		}
 	}
 
-	private int searchIndex(MenuEntry[] entries, String option, String target, boolean strict)
-	{
-		for (int i = entries.length - 1; i >= 0; i--)
-		{
-			MenuEntry entry = entries[i];
-			String entryOption = Text.removeTags(entry.getOption()).toLowerCase();
-			String entryTarget = Text.removeTags(entry.getTarget()).toLowerCase();
-
-			if (strict)
-			{
-				if (entryOption.equals(option) && entryTarget.equals(target))
-				{
-					return i;
-				}
-			}
-			else
-			{
-				if (entryOption.contains(option.toLowerCase()) && entryTarget.equals(target))
-				{
-					return i;
-				}
-			}
-		}
-
-		return -1;
-	}
-
-	private void swap(String optionA, String optionB, String target, int index)
-	{
-		swap(optionA, optionB, target, index, true);
-	}
-
-	private void swap(String optionA, String optionB, String target, int index, boolean strict)
+	private boolean swap(String option, String target, int index, boolean strict)
 	{
 		MenuEntry[] menuEntries = client.getMenuEntries();
 
-		int thisIndex = findIndex(menuEntries, index, optionB, target, strict);
-		int optionIdx = findIndex(menuEntries, thisIndex, optionA, target, strict);
+		// find option to swap with
+		int optionIdx = findIndex(menuEntries, index, option, target, strict);
 
-		if (thisIndex >= 0 && optionIdx >= 0)
+		if (optionIdx >= 0)
 		{
-			swap(optionIndexes, menuEntries, optionIdx, thisIndex);
+			swap(optionIndexes, menuEntries, optionIdx, index);
+			return true;
 		}
-	}
 
-	private void swap(ArrayListMultimap<String, Integer> optionIndexes, MenuEntry[] entries, int index1, int index2)
-	{
-		MenuEntry entry = entries[index1];
-		entries[index1] = entries[index2];
-		entries[index2] = entry;
-
-		client.setMenuEntries(entries);
-
-		// Rebuild option indexes
-		optionIndexes.clear();
-		int idx = 0;
-		for (MenuEntry menuEntry : entries)
-		{
-			String option = Text.removeTags(menuEntry.getOption()).toLowerCase();
-			optionIndexes.put(option, idx++);
-		}
+		return false;
 	}
 
 	private int findIndex(MenuEntry[] entries, int limit, String option, String target, boolean strict)
@@ -363,7 +566,7 @@ public class MenuSwapperPlugin extends Plugin implements KeyListener
 				String entryTarget = Text.removeTags(entry.getTarget()).toLowerCase();
 
 				// Limit to the last index which is prior to the current entry
-				if (idx <= limit && entryTarget.equals(target))
+				if (idx < limit && entryTarget.equals(target))
 				{
 					return idx;
 				}
@@ -372,7 +575,7 @@ public class MenuSwapperPlugin extends Plugin implements KeyListener
 		else
 		{
 			// Without strict matching we have to iterate all entries up to the current limit...
-			for (int i = limit; i >= 0; i--)
+			for (int i = limit - 1; i >= 0; i--)
 			{
 				MenuEntry entry = entries[i];
 				String entryOption = Text.removeTags(entry.getOption()).toLowerCase();
@@ -389,53 +592,66 @@ public class MenuSwapperPlugin extends Plugin implements KeyListener
 		return -1;
 	}
 
-	private void swap(String optionA, String optionB, String target, boolean strict)
+	private void swap(ArrayListMultimap<String, Integer> optionIndexes, MenuEntry[] entries, int index1, int index2)
 	{
-		MenuEntry[] entries = client.getMenuEntries();
+		MenuEntry entry1 = entries[index1],
+			entry2 = entries[index2];
 
-		int idxA = searchIndex(entries, optionA, target, strict);
-		int idxB = searchIndex(entries, optionB, target, strict);
+		entries[index1] = entry2;
+		entries[index2] = entry1;
 
-		if (idxA >= 0 && idxB >= 0)
+		client.setMenuEntries(entries);
+
+		// Update optionIndexes
+		String option1 = Text.removeTags(entry1.getOption()).toLowerCase(),
+			option2 = Text.removeTags(entry2.getOption()).toLowerCase();
+
+		List<Integer> list1 = optionIndexes.get(option1),
+			list2 = optionIndexes.get(option2);
+
+		// call remove(Object) instead of remove(int)
+		list1.remove((Integer) index1);
+		list2.remove((Integer) index2);
+
+		sortedInsert(list1, index2);
+		sortedInsert(list2, index1);
+	}
+
+	private static <T extends Comparable<? super T>> void sortedInsert(List<T> list, T value) // NOPMD: UnusedPrivateMethod: false positive
+	{
+		int idx = Collections.binarySearch(list, value);
+		list.add(idx < 0 ? -idx - 1 : idx, value);
+	}
+
+	private void removeShiftClickCustomizationMenus()
+	{
+		menuManager.removeManagedCustomMenu(FIXED_INVENTORY_TAB_CONFIGURE);
+		menuManager.removeManagedCustomMenu(FIXED_INVENTORY_TAB_SAVE);
+		menuManager.removeManagedCustomMenu(RESIZABLE_BOTTOM_LINE_INVENTORY_TAB_CONFIGURE);
+		menuManager.removeManagedCustomMenu(RESIZABLE_BOTTOM_LINE_INVENTORY_TAB_SAVE);
+		menuManager.removeManagedCustomMenu(RESIZABLE_INVENTORY_TAB_CONFIGURE);
+		menuManager.removeManagedCustomMenu(RESIZABLE_INVENTORY_TAB_SAVE);
+	}
+
+	private void refreshShiftClickCustomizationMenus()
+	{
+		removeShiftClickCustomizationMenus();
+		if (configuringShiftClick)
 		{
-			MenuEntry entry = entries[idxA];
-			entries[idxA] = entries[idxB];
-			entries[idxB] = entry;
-
-			client.setMenuEntries(entries);
+			menuManager.addManagedCustomMenu(FIXED_INVENTORY_TAB_SAVE);
+			menuManager.addManagedCustomMenu(RESIZABLE_BOTTOM_LINE_INVENTORY_TAB_SAVE);
+			menuManager.addManagedCustomMenu(RESIZABLE_INVENTORY_TAB_SAVE);
+		}
+		else
+		{
+			menuManager.addManagedCustomMenu(FIXED_INVENTORY_TAB_CONFIGURE);
+			menuManager.addManagedCustomMenu(RESIZABLE_BOTTOM_LINE_INVENTORY_TAB_CONFIGURE);
+			menuManager.addManagedCustomMenu(RESIZABLE_INVENTORY_TAB_CONFIGURE);
 		}
 	}
 
-	@Override
-	public void keyTyped(KeyEvent e)
+	private boolean shiftModifier()
 	{
-	}
-
-	@Override
-	public void keyPressed(KeyEvent e)
-	{
-		if (e.getKeyCode() == KeyEvent.VK_SHIFT)
-		{
-			shiftHeld = true;
-		}
-	}
-
-	@Override
-	public void keyReleased(KeyEvent e)
-	{
-		if (e.getKeyCode() == KeyEvent.VK_SHIFT)
-		{
-			shiftHeld = false;
-		}
-	}
-
-	@Subscribe
-	public void onFocusChanged(FocusChanged event)
-	{
-		if (!event.isFocused())
-		{
-			shiftHeld = false;
-		}
+		return client.isKeyPressed(KeyCode.KC_SHIFT);
 	}
 }
-

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
@@ -115,6 +115,9 @@ public class MenuSwapperPlugin extends Plugin
 		swap("talk-to", "zahur", "clean", () -> config.swapZahur() == ZahurMode.CLEAN);
 		swap("talk-to", "zahur", "decant", () -> config.swapZahur() == ZahurMode.DECANT);
 		swap("talk-to", "zahur", "make unfinished potion(s)", () -> config.swapZahur() == ZahurMode.MAKE_POTION);
+		swapContains("talk-to", target -> target.startsWith("trader crewmember"), "trade", () -> !shiftModifier() && config.swapTraderCrewmemberLeftClick() == CharterShipsMode.TRADE);
+		swap("talk-to", "charter", () -> !shiftModifier() && config.swapTraderCrewmemberLeftClick() == CharterShipsMode.CHARTER);
+		swap("talk-to",  "charter-to", () -> !shiftModifier() && config.swapTraderCrewmemberLeftClick() == CharterShipsMode.LAST_DESTINATION);
 
 		swap("wear", "tele to poh", () -> !shiftModifier() && config.swapConsCape());
 		swap("wear", "gem mine", () -> !shiftModifier() && config.swapKaramjaGlovesLeftClick() == KaramjaGlovesMode.GEM_MINE);
@@ -133,19 +136,19 @@ public class MenuSwapperPlugin extends Plugin
 
 		swap("activate", "teleport to destination", () -> config.swapTeleportToDestination() == ObeliskMode.TELEPORT_TO_DESTINATION);
 		swap("activate", "set destination", () -> config.swapTeleportToDestination() == ObeliskMode.SET_DESTINATION);
+
 		swap("ardougne", "edgeville", config::swapWildernessLever);
+
 		swapContains("attack", target -> target.startsWith("hoop snake"), "stun", config::swapStun);
 		swap("cast", "standard", () -> !shiftModifier() && config.swapSpellbookSwapLeftClick() == SpellbookSwapMode.STANDARD);
 		swap("cast", "ancient", () -> !shiftModifier() && config.swapSpellbookSwapLeftClick() == SpellbookSwapMode.ANCIENT);
 		swap("cast", "arceuus", () -> !shiftModifier() && config.swapSpellbookSwapLeftClick() == SpellbookSwapMode.ARCEUUS);
+
 		swap("open (normal)", "open (private)", config::swapGodWarsDoor);
 		swap("close", "search", config::swapSearch);
 		swap("shut", "search", config::swapSearch);
 		swap("shoo-away", "pet", config::swapStrayDog);
 		swap("standard", "slayer", config::dagganothKingsLadder);
-		swap("talk-to", "trade", () -> !shiftModifier() && config.swapTraderCrewmemberLeftClick() == CharterShipsMode.TRADE);
-		swap("talk-to", "charter", () -> !shiftModifier() && config.swapTraderCrewmemberLeftClick() == CharterShipsMode.CHARTER);
-		swapContains("talk-to", alwaysTrue(), "charter-to", () -> !shiftModifier() && config.swapTraderCrewmemberLeftClick() == CharterShipsMode.LAST_DESTINATION);
 		swap("lletya", "prifddinas", () -> !shiftModifier() && config.swapTeleCrystal());
 	}
 

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
@@ -30,12 +30,13 @@
 package io.ryoung.menuswapperextended;
 
 import com.google.common.annotations.VisibleForTesting;
+import static com.google.common.base.Predicates.alwaysTrue;
+import static com.google.common.base.Predicates.equalTo;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.inject.Provides;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -43,7 +44,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import javax.inject.Inject;
-
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
@@ -73,9 +73,6 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.menuentryswapper.MenuEntrySwapperConfig;
 import net.runelite.client.util.Text;
 import org.apache.commons.lang3.ArrayUtils;
-
-import static com.google.common.base.Predicates.alwaysTrue;
-import static com.google.common.base.Predicates.equalTo;
 
 @Slf4j
 @PluginDescriptor(
@@ -317,8 +314,8 @@ public class MenuSwapperPlugin extends Plugin
 	public void onWidgetMenuOptionClicked(WidgetMenuOptionClicked event)
 	{
 		if (event.getWidget() == WidgetInfo.FIXED_VIEWPORT_INVENTORY_TAB
-				|| event.getWidget() == WidgetInfo.RESIZABLE_VIEWPORT_INVENTORY_TAB
-				|| event.getWidget() == WidgetInfo.RESIZABLE_VIEWPORT_BOTTOM_LINE_INVENTORY_TAB)
+			|| event.getWidget() == WidgetInfo.RESIZABLE_VIEWPORT_INVENTORY_TAB
+			|| event.getWidget() == WidgetInfo.RESIZABLE_VIEWPORT_BOTTOM_LINE_INVENTORY_TAB)
 		{
 			configuringShiftClick = event.getMenuOption().equals(CONFIGURE) && Text.removeTags(event.getMenuTarget()).equals(MENU_TARGET);
 			refreshShiftClickCustomizationMenus();

--- a/src/main/java/io/ryoung/menuswapperextended/MorytaniaLegsMode.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MorytaniaLegsMode.java
@@ -24,12 +24,13 @@
  */
 package io.ryoung.menuswapperextended;
 
+import java.util.function.Predicate;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum MorytaniaLegsMode
+public enum MorytaniaLegsMode implements SwapMode
 {
 	WEAR("Wear"),
 	ECTO_TELEPORT("Ecto Teleport"),
@@ -41,5 +42,17 @@ public enum MorytaniaLegsMode
 	public String toString()
 	{
 		return option;
+	}
+
+	@Override
+	public boolean checkShift()
+	{
+		return true;
+	}
+
+	@Override
+	public Predicate<String> checkTarget()
+	{
+		return target -> target.startsWith("morytania legs");
 	}
 }

--- a/src/main/java/io/ryoung/menuswapperextended/ObeliskMode.java
+++ b/src/main/java/io/ryoung/menuswapperextended/ObeliskMode.java
@@ -25,22 +25,29 @@
 
 package io.ryoung.menuswapperextended;
 
+import java.util.function.Predicate;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum ObeliskMode
+public enum ObeliskMode implements SwapMode
 {
 	ACTIVATE("Activate"),
 	TELEPORT_TO_DESTINATION("Teleport to destination"),
 	SET_DESTINATION("Set destination");
 
-	private final String name;
+	private final String option;
 
 	@Override
 	public String toString()
 	{
-		return name;
+		return option;
+	}
+
+	@Override
+	public Predicate<String> checkTarget()
+	{
+		return target -> target.equals("obelisk");
 	}
 }

--- a/src/main/java/io/ryoung/menuswapperextended/PharaohSceptreMode.java
+++ b/src/main/java/io/ryoung/menuswapperextended/PharaohSceptreMode.java
@@ -24,12 +24,13 @@
  */
 package io.ryoung.menuswapperextended;
 
+import java.util.function.Predicate;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum PharaohSceptreMode
+public enum PharaohSceptreMode implements SwapMode
 {
 	WIELD("Wield"),
 	JALSAVRAH("Jalsavrah"),
@@ -42,5 +43,17 @@ public enum PharaohSceptreMode
 	public String toString()
 	{
 		return option;
+	}
+
+	@Override
+	public boolean checkShift()
+	{
+		return true;
+	}
+
+	@Override
+	public Predicate<String> checkTarget()
+	{
+		return target -> target.startsWith("pharaoh's sceptre");
 	}
 }

--- a/src/main/java/io/ryoung/menuswapperextended/Swap.java
+++ b/src/main/java/io/ryoung/menuswapperextended/Swap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Vitorebom
+ * Copyright (c) 2020, Adam <Adam@sigterm.info>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,23 +24,16 @@
  */
 package io.ryoung.menuswapperextended;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+		import java.util.function.Predicate;
+		import java.util.function.Supplier;
+		import lombok.Value;
 
-@Getter
-@RequiredArgsConstructor
-public enum PharaohSceptreMode
+@Value
+class Swap
 {
-	WIELD("Wield"),
-	JALSAVRAH("Jalsavrah"),
-	JALEUSTROPHOS("Jaleustrophos"),
-	JALDRAOCHT("Jaldraocht");
-
-	private final String option;
-
-	@Override
-	public String toString()
-	{
-		return option;
-	}
+	private Predicate<String> optionPredicate;
+	private Predicate<String> targetPredicate;
+	private String swappedOption;
+	private Supplier<Boolean> enabled;
+	private boolean strict;
 }

--- a/src/main/java/io/ryoung/menuswapperextended/Swap.java
+++ b/src/main/java/io/ryoung/menuswapperextended/Swap.java
@@ -24,9 +24,9 @@
  */
 package io.ryoung.menuswapperextended;
 
-		import java.util.function.Predicate;
-		import java.util.function.Supplier;
-		import lombok.Value;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import lombok.Value;
 
 @Value
 class Swap

--- a/src/main/java/io/ryoung/menuswapperextended/SwapMode.java
+++ b/src/main/java/io/ryoung/menuswapperextended/SwapMode.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2020, SomeZer0
+ * Copyright (c) 2021, Ron Young <https://github.com/raiyni>
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
  *
  * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
+ *     list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -22,38 +22,24 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 package io.ryoung.menuswapperextended;
 
 import java.util.function.Predicate;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
-public enum SpellbookSwapMode implements SwapMode
+public interface SwapMode
 {
-	CAST("Cast"),
-	STANDARD("Standard"),
-	ANCIENT("Ancient"),
-	ARCEUUS("Arceuus");
-
-	private final String option;
-
-	@Override
-	public String toString()
-	{
-		return option;
-	}
-
-	@Override
-	public boolean checkShift()
-	{
+	default boolean strict() {
 		return true;
 	}
 
-	@Override
-	public Predicate<String> checkTarget()
-	{
-		return target -> target.startsWith("spellbook swap");
+	default boolean checkShift() {
+		return false;
 	}
+
+	default Predicate<String> checkTarget() {
+		return s -> true;
+	}
+
+	String getOption();
 }

--- a/src/main/java/io/ryoung/menuswapperextended/ZahurMode.java
+++ b/src/main/java/io/ryoung/menuswapperextended/ZahurMode.java
@@ -24,12 +24,13 @@
  */
 package io.ryoung.menuswapperextended;
 
+import java.util.function.Predicate;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum ZahurMode
+public enum ZahurMode implements SwapMode
 {
 	TALK("Talk-to"),
 	DECANT("Decant"),
@@ -42,5 +43,11 @@ public enum ZahurMode
 	public String toString()
 	{
 		return option;
+	}
+
+	@Override
+	public Predicate<String> checkTarget()
+	{
+		return target -> target.equals("zahur");
 	}
 }


### PR DESCRIPTION
Updated version to 1.7
Pharaoh sceptre options re-ordered
Send parcel option removed - added to Runelite
Decant option removed - added to Runelite
Stray dog config indentation fixed
Razmire Keelgan's builder's store swap description fixed to say the swap is done from "talk-to"

Notes:
Search might be outdated due to a menu option rearrangement