### PR TITLE
Add Fremennik Sea Boots swap

### DIFF
--- a/src/main/java/io/ryoung/menuswapperextended/FremennikSeaBootsMode.java
+++ b/src/main/java/io/ryoung/menuswapperextended/FremennikSeaBootsMode.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021, Scott Brunton <https://github.com/scobrun>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.ryoung.menuswapperextended;
+
+import java.util.function.Predicate;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FremennikSeaBootsMode implements SwapMode
+{
+ 	WEAR("Wear"),
+	TELEPORT("Teleport");
+
+	private final String option;
+
+	@Override
+	public String toString()
+	{
+		return option;
+	}
+
+	@Override
+	public Predicate<String> checkTarget()
+	{
+		return target -> target.startsWith("fremennik sea boots");
+	}
+
+}

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
@@ -335,4 +335,15 @@ public interface MenuSwapperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+			keyName = "swapFremennikSeaBootsLeftClick",
+			name = "Fremennik Sea Boots",
+			description = "Change the left-click option on Fremennik Sea Boots",
+			section = itemSection
+	)
+	default FremennikSeaBootsMode swapFremennikSeaBootsLeftClick()
+	{
+		return FremennikSeaBootsMode.WEAR;
+	}
 }

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
@@ -123,6 +123,7 @@ public class MenuSwapperPlugin extends Plugin
 		swapMode("wear", MorytaniaLegsMode.class, config::swapMorytaniaLegsLeftClick);
 		swapMode("wear", ArdougneCloakMode.class, config::swapArdougneCloakLeftClick);
 		swapMode("wear", DrakansMedallionMode.class, config::swapDrakansMedallionLeftClick);
+		swapMode("wear", FremennikSeaBootsMode.class, config::swapFremennikSeaBootsLeftClick);
 		swapMode("wield", PharaohSceptreMode.class, config::swapPharaohSceptreLeftClick);
 		swapMode("activate", ObeliskMode.class, config::swapTeleportToDestination);
 


### PR DESCRIPTION
Added an option to swap the "wear" and "teleport" entries for the Fremennik Sea Boots.

A potential use case would be for Vorkath where you use the boots to teleport back to Rellekka after restoring your special attack meter at your POH. Also good as a one-click emergency teleport.

![2021-05-08 23_39_23-RuneLite - Sarbles](https://user-images.githubusercontent.com/16354607/117555412-dd375880-b056-11eb-919e-c0a38bcdef4c.png)

![2021-05-08 23_40_24-RuneLite - Sarbles](https://user-images.githubusercontent.com/16354607/117555413-ddcfef00-b056-11eb-953a-53e91bc19ad4.png)

