### PR TITLE
Add use for translation book

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.13-SNAPSHOT'
+def runeLiteVersion = '1.7.19'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
@@ -467,5 +467,16 @@ public interface MenuSwapperConfig extends Config
 	{
 		return NMZBarrelMode.CHECK;
 	}
+
+	@ConfigItem(
+		keyName = "translationBookUse",
+		name = "Translation Book Use",
+		description = "Change the left click option to use for translation book from MM2.",
+		section = itemSection
+	)
+	default boolean translationBook()
+	{
+		return false;
+	}
 }
 

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
@@ -150,6 +150,7 @@ public class MenuSwapperPlugin extends Plugin
 		swap("wield", "reminisce", config::kharedstsMemoirs);
 		swap("look-at", "continue-trek", config::templeTrekkking);
 		swap("look at", "snow", config::snowSnowglobe);
+		swap("read", target -> target.startsWith("translation book"), "use", config::translationBook);
 	}
 
 	private <T extends Enum<?> & SwapMode> void swapMode(String option, Class<T> mode, Supplier<T> enumGet)


### PR DESCRIPTION
The translation book from MM2 has some niche uses in Barbarian Assault speed-running strategies: see https://youtu.be/F8pVTnFlSo0?t=452. This makes performing the linked method less intense, although it's still an inferior method for accounts that haven't finished MM2 and have access to both the scrawled and translated notes (mentioned in next section of linked guide). Thought it would make sense if it were added here.