### PR TITLE
Swap Open with Pick-lock on chests

### DIFF
--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
@@ -84,6 +84,17 @@ public interface MenuSwapperConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "swapPickLock",
+		name = "Pick-lock",
+		description = "Swap Open with Pick-lock on chests",
+		section = objectSection
+	)
+	default boolean swapPickLock()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "swapBuyPlank",
 		name = "Buy-Plank",
 		description = "Swap Talk-to with Buy-Plank on Sawmill Operator",

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
@@ -137,6 +137,7 @@ public class MenuSwapperPlugin extends Plugin
 		swap("open (normal)", "open (private)", config::swapGodWarsDoor);
 		swap("close", "search", config::swapSearch);
 		swap("shut", "search", config::swapSearch);
+		swap("open", "pick-lock", config::swapPickLock);
 		swap("shoo-away", "pet", config::swapStrayDog);
 		swap("standard", "slayer", config::dagganothKingsLadder);
 		swap("lletya", "prifddinas", () -> !shiftModifier() && config.swapTeleCrystal());


### PR DESCRIPTION
The open option on chests that also have a pick-lock option does nothing;
at most a message is shown to the user telling them the chest is locked.

closes #100