### PR TITLE
Tackle box swap

### DIFF
--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperConfig.java
@@ -216,6 +216,17 @@ public interface MenuSwapperConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "emptyTacklebox",
+		name = "Tackle box",
+		description = "Change the left-click option to Empty on Tackle box",
+		section = itemSection
+	)
+	default TackleBoxMode emptyTacklebox()
+	{
+		return TackleBoxMode.EMPTY;
+	}
+
+	@ConfigItem(
 		keyName = "swapTraderCrewmemberLeftClick",
 		name = "Charter Ships",
 		description = "Change the left-click option on Trader Crewmembers on Charter ships",

--- a/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
+++ b/src/main/java/io/ryoung/menuswapperextended/MenuSwapperPlugin.java
@@ -124,6 +124,7 @@ public class MenuSwapperPlugin extends Plugin
 		swapMode("wear", FremennikSeaBootsMode.class, config::swapFremennikSeaBootsLeftClick);
 		swapMode("wear", MythicalCapeMode.class, config::swapMythicalCapeLeftClick);
 		swapMode("wield", PharaohSceptreMode.class, config::swapPharaohSceptreLeftClick);
+		swapMode("view", TackleBoxMode.class, config::emptyTackleBox);
 		swap("wield", "cast bloom", config::castBloom);
 		swap("wield", "bloom", config::castBloom);
 		swapMode("activate", ObeliskMode.class, config::swapTeleportToDestination);

--- a/src/main/java/io/ryoung/menuswapperextended/TackleBoxMode.java
+++ b/src/main/java/io/ryoung/menuswapperextended/TackleBoxMode.java
@@ -1,0 +1,28 @@
+package io.ryoung.menuswapperextended;
+
+import java.util.function.Predicate;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TackleBoxMode implements SwapMode
+{
+ 	VIEW("View"),
+	EMPTY("Empty");
+
+	private final String option;
+
+	@Override
+	public String toString()
+	{
+		return option;
+	}
+
+	@Override
+	public Predicate<String> checkTarget()
+	{
+		return target -> target.startsWith("tackle box");
+	}
+
+}


### PR DESCRIPTION
(Hopefully) swaps the default "View" option on the Tackle box to "Empty".

Use cases would be having things like a preset fishing setup ready to go inside the box, or saving a right click+left click for drift net fishing.