### PR TITLE
Changes def runeLiteVersion to 'latest.release'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.13-SNAPSHOT'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion


### PR DESCRIPTION
This will allow for your development environment to use the latest stable runelite release.